### PR TITLE
fix(e2e): refresh smoke tests for the new UI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,10 @@ jobs:
 
       - run: pnpm typecheck
 
+      - run: pnpm exec playwright install --with-deps chromium
+
+      - run: pnpm test:e2e
+
       - run: pnpm build
 
       - uses: actions/configure-pages@v5

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,7 +1,13 @@
 import { expect, test } from '@playwright/test';
 
+/**
+ * The CLI tab highlights for both `/` (the landing/welcome page) and
+ * `/cli/` (the dedicated terminal route) — see `activeTabFromPathname`
+ * in `components/nav-bar/tabs.ts`.
+ */
 const TABS = [
   { path: '/', label: 'CLI' },
+  { path: '/cli/', label: 'CLI' },
   { path: '/companies/', label: 'Companies' },
   { path: '/blog/', label: 'Blog' },
   { path: '/team/', label: 'Team' },
@@ -9,42 +15,58 @@ const TABS = [
 ];
 
 for (const { path, label } of TABS) {
-  test(`${label} tab renders with the correct active nav item`, async ({ page }) => {
+  test(`${path} renders with "${label}" as the active nav item`, async ({ page }) => {
     await page.goto(path);
     const active = page.locator('nav a[aria-current="page"]');
-    await expect(active).toHaveText(label);
+    // `/` runs the welcome boot animation before the NavBar mounts; bump
+    // the auto-wait so that path doesn't flake on a slow static serve.
+    await expect(active).toHaveText(label, { timeout: 15_000 });
   });
 }
 
 test('blog index lists all 8 posts', async ({ page }) => {
   await page.goto('/blog/');
-  const cards = page.locator('a:has(h2)');
-  await expect(cards).toHaveCount(8);
+  // The visible UI is a file-tree, but the page also renders an `sr-only`
+  // index for AI/SEO crawlers — one `<li>` per post — which is the most
+  // stable count selector regardless of how the visible tree is rendered.
+  const items = page.locator('section[aria-label=">commit blog index"] li');
+  await expect(items).toHaveCount(8);
 });
 
-test('individual blog post renders with headings and article JSON-LD', async ({ page }) => {
+test('individual blog post renders with headings and Article JSON-LD', async ({ page }) => {
   await page.goto('/blog/browser-redefined/');
   await expect(page.locator('article h1')).toBeVisible();
-  const jsonLd = await page.locator('script[type="application/ld+json"]').nth(1).textContent();
-  expect(jsonLd).toContain('"@type":"Article"');
+  // Multiple JSON-LD scripts now ship per page (Organization/WebSite from
+  // the root layout, Article + BreadcrumbList from the post). Search the
+  // collection rather than relying on a fixed index.
+  const scripts = await page.locator('script[type="application/ld+json"]').allTextContents();
+  const hasArticle = scripts.some((s) => /"@type"\s*:\s*"Article"/.test(s));
+  expect(hasArticle).toBe(true);
 });
 
 test('terminal accepts help command and lists commands', async ({ page }) => {
-  await page.goto('/');
+  // Use `/cli/` rather than `/` — the dedicated route mounts the terminal
+  // immediately, with no boot animation gating the input.
+  await page.goto('/cli/');
   const input = page.locator('input[aria-label="Terminal command input"]');
-  // Wait for boot animation to finish + prompt to enable
-  await expect(input).toBeEnabled({ timeout: 5000 });
-  await input.fill('help');
-  await input.press('Enter');
+  await expect(input).toBeEnabled({ timeout: 10_000 });
+  // The prompt input auto-sizes via `width: ${value.length}ch` for the
+  // blinking-cursor look, so an empty input has zero width and trips
+  // Playwright's "visible" check. Skip actionability and drive the input
+  // straight via the keyboard.
+  await input.focus();
+  await page.keyboard.type('help');
+  await page.keyboard.press('Enter');
   await expect(page.getByText(/Here are the available commands/i)).toBeVisible();
 });
 
 test('terminal ls lists top-level directories', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/cli/');
   const input = page.locator('input[aria-label="Terminal command input"]');
-  await expect(input).toBeEnabled({ timeout: 5000 });
-  await input.fill('ls');
-  await input.press('Enter');
+  await expect(input).toBeEnabled({ timeout: 10_000 });
+  await input.focus();
+  await page.keyboard.type('ls');
+  await page.keyboard.press('Enter');
   const output = page.locator('[role="log"]');
   await expect(output).toContainText('about');
   await expect(output).toContainText('team');
@@ -52,8 +74,14 @@ test('terminal ls lists top-level directories', async ({ page }) => {
   await expect(output).toContainText('blog');
 });
 
-test('/about/legal serves a redirect page with a visible fallback link', async ({ page }) => {
-  await page.goto('/about/legal/', { waitUntil: 'domcontentloaded' });
-  const link = page.locator('a[href="https://www.redriverwest.com/legal"]');
-  await expect(link).toBeVisible();
+test('/about/legal serves a redirect page with a visible fallback link', async ({ request }) => {
+  // The page does an immediate `window.location.replace(...)` (with a
+  // <noscript> meta-refresh fallback), so any browser visit redirects
+  // before assertions can run. Fetch the HTML directly instead — the
+  // fallback link must be present in the served markup so users with the
+  // redirect blocked still have a path forward.
+  const res = await request.get('/about/legal/');
+  expect(res.status()).toBe(200);
+  const html = await res.text();
+  expect(html).toContain('href="https://www.redriverwest.com/legal"');
 });


### PR DESCRIPTION
## Summary
- Update Playwright smoke tests so they match the post-Next.js-migration UI and the static-export deploy.
- Re-enable the e2e step in `.github/workflows/deploy.yml` (it was temporarily skipped in 79739b1).

## What changed in the tests
- **Blog index** — `a:has(h2)` no longer matches; the visible UI is a file-tree. Count the `sr-only` AI/SEO index instead (`section[aria-label=">commit blog index"] li`, exactly 8).
- **Article JSON-LD** — the root layout now ships Organization + WebSite scripts ahead of the page-level Article + BreadcrumbList, so `nth(1)` returned the wrong node. Scan all `application/ld+json` scripts and assert one contains `"@type":"Article"`.
- **Terminal tests** — moved from `/` to `/cli/` (no boot animation gating the input) and switched to `focus()` + `keyboard.type(...)`. The prompt input auto-sizes via `width: ${value.length}ch`, so an empty box has zero width and trips Playwright's visibility check on `fill`/`press`.
- **/about/legal** — the page fires `window.location.replace(...)` immediately (with a `<noscript>` meta-refresh fallback), so a browser visit always navigates away before assertions can run. Fetch the HTML directly via the `request` fixture — the assertion we care about is a static-HTML property anyway.
- **Tabs** — added an explicit `/cli/` row so we cover both routes that map to the CLI tab; bumped the auto-wait on `/` to absorb the welcome boot animation on a slow static serve.

Closes #1.

## Test plan
- [x] `CI=1 pnpm test:e2e` locally — 11 passed (~20s)
- [ ] Deploy workflow runs e2e + build successfully on this PR's commit