### PR TITLE
fix(cli): render team profiles via shared ProfileCard

### DIFF
--- a/lib/commands.tsx
+++ b/lib/commands.tsx
@@ -1,12 +1,13 @@
-import Image from 'next/image';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { CompanyCard } from '@/components/cards/CompanyCard';
+import { ProfileCard } from '@/components/cards/ProfileCard';
 import { Firework } from '@/components/firework/Firework';
 import { COMPANIES } from './companies';
 import type { FsDir } from './filesystem';
 import { getNode, isDirectory, listDirectory, readFile, resolvePath } from './filesystem';
 import { decrypt } from './tea';
+import { TEAM } from './team';
 
 export type CommandContext = {
   fs: FsDir;
@@ -43,66 +44,19 @@ function Blue({ children, href }: { children: ReactNode; href: string }) {
   );
 }
 
-function parseKeyedText(text: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  let lastKey: string | null = null;
-  for (const raw of text.split('\n')) {
-    const line = raw.trim();
-    const idx = line.indexOf(':');
-    if (idx > 0 && idx < 30) {
-      const key = line.slice(0, idx).trim();
-      const value = line.slice(idx + 1).trim();
-      out[key] = value;
-      lastKey = key;
-    } else if (lastKey && line) {
-      out[lastKey] = `${out[lastKey]}\n${line}`;
-    }
-  }
-  return out;
-}
-
+/** Team members and companies are rendered by looking them up by slug and
+ *  delegating to the shared ProfileCard / CompanyCard components — same ones
+ *  used by the file-tree viewer, so `cat team/x.txt` / `cat companies/x.txt`
+ *  and the tree preview stay in sync. */
 function TeamProfileCard({ file }: { file: string }) {
-  const p = parseKeyedText(file);
-  const avatar = p.Avatar ? `/${p.Avatar.replace(/^\//, '')}` : undefined;
-  return (
-    <div className="terminal-profile">
-      {avatar ? (
-        <div className="terminal-profile-image">
-          <Image src={avatar} alt={`${p.Name ?? ''}'s portrait`} width={96} height={96} />
-        </div>
-      ) : null}
-      <div className="terminal-profile-data">
-        <span className="terminal-rule" />
-        <p>
-          <Yellow>
-            {p.Name}, {p.Role}
-          </Yellow>
-        </p>
-        <p>
-          <Yellow>{p.Location}</Yellow>
-        </p>
-        {p.Github ? (
-          <p>
-            <Blue href={p.Github}>{p.Github}</Blue>
-          </p>
-        ) : null}
-        {p.LinkedIn ? (
-          <p>
-            <Blue href={p.LinkedIn}>{p.LinkedIn}</Blue>
-          </p>
-        ) : null}
-        <span className="terminal-rule" />
-      </div>
-    </div>
-  );
+  const slug = file.match(/^slug:(.+)$/)?.[1]?.trim();
+  const member = slug ? TEAM.find((m) => m.slug === slug) : undefined;
+  if (!member) return null;
+  return <ProfileCard member={member} />;
 }
 
-/** Companies are rendered by looking them up in COMPANIES by slug and
- *  delegating to CompanyCard — same component used by the file-tree viewer,
- *  so the CLI's `cat companies/x.txt` and the tree preview stay in sync. */
 function CompanyProfileCard({ file }: { file: string }) {
-  const match = file.match(/^slug:(.+)$/);
-  const slug = match?.[1]?.trim();
+  const slug = file.match(/^slug:(.+)$/)?.[1]?.trim();
   const company = slug ? COMPANIES.find((c) => c.slug === slug) : undefined;
   if (!company) return null;
   return <CompanyCard company={company} />;

--- a/lib/commands.tsx
+++ b/lib/commands.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { CompanyCard } from '@/components/cards/CompanyCard';
 import { ProfileCard } from '@/components/cards/ProfileCard';
 import { Firework } from '@/components/firework/Firework';
+import { Linkify } from '@/components/linkify/Linkify';
 import { COMPANIES } from './companies';
 import type { FsDir } from './filesystem';
 import { getNode, isDirectory, listDirectory, readFile, resolvePath } from './filesystem';
@@ -134,7 +135,16 @@ function renderFileAs(path: string, slug: string, content: string): ReactNode {
   if (/\/blog\//.test(path) && path.endsWith('.txt')) {
     return <BlogCard slug={slug} file={content} />;
   }
-  return <pre style={{ whiteSpace: 'pre-wrap', margin: 0 }}>{content}</pre>;
+  // Fallback for plain-text files (about/readme.txt, about/projects.txt,
+  // about/contact.txt, team/advisors/advisors.txt, …). Match the file-tree
+  // preview by running the body through <Linkify/> so emails and URLs are
+  // clickable here too — same content shouldn't render different links
+  // depending on whether the user `cat`-s it or clicks it in the sidebar.
+  return (
+    <div style={{ whiteSpace: 'pre-wrap', margin: 0 }}>
+      <Linkify text={content} />
+    </div>
+  );
 }
 
 const ls: Command = {

--- a/lib/filesystem.ts
+++ b/lib/filesystem.ts
@@ -6,21 +6,16 @@ export type FsFile = { type: 'file'; content: string };
 export type FsDir = { type: 'directory'; contents: Record<string, FsNode> };
 export type FsNode = FsFile | FsDir;
 
+/** The file body is just the slug; the card is looked up against TEAM /
+ *  COMPANIES and rendered by the shared ProfileCard / CompanyCard components
+ *  in both the CLI's `cat` and the file-tree viewer. Keeps one source of
+ *  truth for the data — when ProfileCard adds new fields (tagline, focus,
+ *  description, etc.), the CLI picks them up automatically instead of
+ *  rendering a stale subset of a key:value text dump. */
 function fileContentsFromMember(m: (typeof TEAM)[number]): string {
-  const lines: string[] = [
-    `Name: ${m.name}`,
-    `Role: ${m.role}`,
-    `Location: ${m.location}`,
-    `Github: ${m.github}`,
-  ];
-  if (m.linkedin) lines.push(`LinkedIn: ${m.linkedin}`);
-  lines.push(`Avatar: ${m.avatar.replace(/^\//, '')}`);
-  return lines.join('\n');
+  return `slug:${m.slug}`;
 }
 
-/** The file body is just the slug; the card is looked up against COMPANIES
- *  and rendered by the CompanyCard component in both the CLI's `cat` and the
- *  file-tree viewer. Keeps one source of truth for the data. */
 function fileContentsFromCompany(c: (typeof COMPANIES)[number]): string {
   return `slug:${c.slug}`;
 }


### PR DESCRIPTION
## Summary
- `cat team/<slug>.txt` in the CLI was rendering a stale minimal card (avatar, name/role, location, github, linkedin) — never picked up tagline, focus, languages, twitter, website, or description from the ProfileCard redesign.
- Root cause: the team filesystem entry was a key:value text dump (`Name: …`, `Role: …`) parsed by a CLI-local component, while the route `/team/<slug>` and the file-tree sidebar both pull straight from `TEAM` and render `<ProfileCard/>`.
- Fix: mirror the company pattern. File body is just `slug:<slug>`; CLI looks up TEAM by slug and delegates to the shared `<ProfileCard/>`. One source of truth.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (5 expected `prefers-reduced-motion !important` warnings)
- [x] `pnpm build` succeeds
- [x] `pnpm test:e2e` — all 11 pass
- [ ] Verify in browser: `cat team/max.txt` (and other slugs) shows the new ProfileCard with tagline/focus/languages/description, identical to the file-tree preview and `/team/max`

🤖 Generated with [Claude Code](https://claude.com/claude-code)