### PR TITLE
fix(cli): ls sorts directories first, then files

### DIFF
--- a/lib/filesystem.ts
+++ b/lib/filesystem.ts
@@ -172,10 +172,23 @@ export function isDirectory(root: FsDir, path: string): boolean {
   return node !== null && node.type === 'directory';
 }
 
+/** Directories first (alphabetical), then files (alphabetical) — matches the
+ *  ordering used by the file-tree sidebar so `ls` and the tree show the same
+ *  shape for the same directory. Visibility filtering (e.g. the tree hiding
+ *  `private/`) is handled in the renderers, not here. */
 export function listDirectory(root: FsDir, path: string): string[] {
   const node = getNode(root, path);
   if (!node || node.type !== 'directory') return [];
-  return Object.keys(node.contents).sort();
+  const entries = Object.entries(node.contents);
+  const dirs = entries
+    .filter(([, v]) => v.type === 'directory')
+    .map(([name]) => name)
+    .sort((a, b) => a.localeCompare(b));
+  const files = entries
+    .filter(([, v]) => v.type === 'file')
+    .map(([name]) => name)
+    .sort((a, b) => a.localeCompare(b));
+  return [...dirs, ...files];
 }
 
 export function readFile(root: FsDir, path: string): string | null {


### PR DESCRIPTION
## Summary
- `ls` in the CLI was doing flat alphabetical sort, so folders and files were mixed together.
- The file-tree sidebar already groups directories first then files (`FileTree.tsx:56–62`).
- Updated `listDirectory` in `lib/filesystem.ts` to match that ordering so the CLI and the tree show the same shape for the same directory.
- Visibility differences (e.g. the tree hides `team/private/`) are handled in the renderers, not in `listDirectory` — left untouched as requested.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test:e2e` — all 11 pass (incl. `terminal ls lists top-level directories`)
- [ ] Verify in browser: `ls`, `ls team`, `ls about` show dirs first then files

🤖 Generated with [Claude Code](https://claude.com/claude-code)