### PR TITLE
Add training-data stealth portfolio company

### DIFF
--- a/lib/companies.ts
+++ b/lib/companies.ts
@@ -362,6 +362,14 @@ export const COMPANIES: readonly Company[] = [
     stealth: true,
   },
   {
+    slug: 'training-data',
+    company: 'Stealth',
+    oneLiner: 'Training data infrastructure',
+    folder: 'active',
+    avatar: '',
+    stealth: true,
+  },
+  {
     slug: 'uma',
     company: 'UMA',
     oneLiner: 'Intelligent robots that enhance quality of life for everyone',


### PR DESCRIPTION
## Summary
Adds a third stealth entry to the active portfolio in `lib/companies.ts`, mirroring the existing `inference` and `specs` entries.

```ts
{
  slug: 'training-data',
  company: 'Stealth',
  oneLiner: 'Training data infrastructure',
  folder: 'active',
  avatar: '',
  stealth: true,
},
```

Everything flows automatically from `stealth: true`:
- Card renders only `training-data.txt: Permission denied` — no logo, no live GitHub/package fetch
- File tree shows `training-data.txt` in faded green
- Detail page skips the OG image and Organization JSON-LD (not indexed as a real entity)

The `oneLiner` is never shown on the card; it only feeds the hidden page `<title>`/meta description, matching the other two stealth entries.

## Testing
Verified locally with `pnpm dev`:
- `/companies/training-data/` → HTTP 200
- Card renders `training-data.txt: Permission denied`
- Title: `Stealth — Training data infrastructure | >commit`
- Appears in the companies list

🤖 Generated with [Claude Code](https://claude.com/claude-code)