### PR TITLE
fix(file-tree): navigate to base path when clicking inline files from routed pages

### DIFF
--- a/components/file-tree/FileTree.tsx
+++ b/components/file-tree/FileTree.tsx
@@ -201,6 +201,12 @@ export function FileTree({ root, basePath, blogPosts }: Props) {
               router.push(route);
               return;
             }
+            // For inline files: if we're currently on a routed page, navigate back
+            // to the base path first so the inline content can render. Without this,
+            // routedSelection blocks inlineContent from showing.
+            if (routedSelection) {
+              router.push(basePath);
+            }
             setLocalSelected(line.fullPath);
           };
           return (


### PR DESCRIPTION
## Summary
Fixes #43 - Files in the file explorer becoming unclickable after navigating to routed pages

## Problem
When viewing a routed file (e.g., `/team/john/` for `john.txt`) and then clicking an inline file (e.g., `advisors.txt` or `legal.txt`), the file appeared unclickable with no visible effect.

**Root cause:** The `FileTree` component has two types of files:
- **Routed files**: Navigate to dedicated pages (team members, companies, about/readme, etc.)
- **Inline files**: Display content below the tree (advisors.txt, legal.txt, blog summaries)

The inline content is only rendered when `!routedSelection && localSelected` is true. When a routed file was active, `routedSelection` was set from the URL, blocking inline content from rendering even after clicking and setting `localSelected`.

## Solution
Modified the `onClick` handler in `FileTree.tsx` to navigate back to the base path before setting `localSelected` when clicking an inline file while on a routed page. This clears the URL-based `routedSelection`, allowing the inline content to render.

## Changes
- `components/file-tree/FileTree.tsx`: Added navigation to base path when clicking inline files from routed pages (lines 204-209)

## Test plan
- [x] Build succeeds with no errors
- [x] Navigate to `/team/`, click any team member, then click `advisors.txt` - content displays
- [x] Navigate to `/about/`, click `readme.txt`, then click `legal.txt` - content displays
- [x] Direct navigation to inline files still works
- [x] Routed file navigation unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)