### PR TITLE
feat(portfolio): add agent-mux stealth investment

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,8 +51,8 @@ export default function HomePage() {
           <strong>Abel Samot</strong> (Partner), and <strong>Alessandro Ciffo</strong> (Tech Lead).
         </p>
         <p>
-          Active Fund I commitments to date: 3 — one announced (UMA — humanoid robotics), two
-          stealth (disclosure pending).
+          Active Fund I commitments to date: 5 — two announced (UMA — humanoid robotics, Macrodata
+          Labs — training-data infrastructure), three stealth (disclosure pending).
         </p>
         <p>
           Reach out at <a href="mailto:hey@commit.fund">hey@commit.fund</a>. Browse the full site at{' '}

--- a/lib/companies.ts
+++ b/lib/companies.ts
@@ -362,6 +362,14 @@ export const COMPANIES: readonly Company[] = [
     stealth: true,
   },
   {
+    slug: 'agent-mux',
+    company: 'Stealth',
+    oneLiner: 'The Code Editor for AI Agents',
+    folder: 'active',
+    avatar: '',
+    stealth: true,
+  },
+  {
     slug: 'macrodata',
     company: 'Macrodata Labs',
     oneLiner: 'Every strong model starts with great data',


### PR DESCRIPTION
## Summary

- Adds a new stealth entry (`agent-mux`) to the active portfolio in `lib/companies.ts`, sitting alongside the existing `inference` / `specs` teasers. Renders as `agent-mux.txt: Permission denied` in the companies tree and at `/companies/agent-mux/`. No per-company Organization JSON-LD is emitted.
- Bumps the SR-only landing copy in `app/page.tsx` from the stale *"3 commitments — one announced (UMA), two stealth"* (a miss from the Macrodata PR) to the accurate *"5 — two announced (UMA, Macrodata Labs), three stealth"*.

## Test plan

Verified locally against `next dev` — see [verification report](#) in the working session.

- [x] `/companies/` lists `agent-mux.txt` with the `fileStealth` class (dimmed/italic), alongside `inference.txt` and `specs.txt`
- [x] `/companies/agent-mux/` renders the stealth card markup (`agent-mux.txt: Permission denied`)
- [x] No per-company Organization JSON-LD on `/companies/agent-mux/` (only the site-wide `>commit` org)
- [x] Breadcrumb JSON-LD still emits with `name: "Stealth"` at the leaf
- [x] `/companies/inference/` and `/companies/specs/` still render correctly
- [x] `/companies/macrodata/` (sanity) still emits its Organization JSON-LD
- [x] Landing page SR-only copy reads "5 — two announced (UMA — humanoid robotics, Macrodata Labs — training-data infrastructure), three stealth (disclosure pending)."
- [x] `pnpm typecheck` clean, `pnpm lint` clean (only pre-existing warnings)

## Note

The `oneLiner` ("The Code Editor for AI Agents") appears in `<title>` and `<meta name="description">` for the stealth page, which is more specific than the existing `inference` / `specs` teasers ("AI inference stack", "Specifications framework"). Intentional — confirmed at decision time — but worth flagging since the route is statically generated and crawler-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)