### PR TITLE
feat(portfolio): order companies public-first, stealth-second, alphabetical

### DIFF
--- a/components/file-tree/FileTree.tsx
+++ b/components/file-tree/FileTree.tsx
@@ -7,7 +7,7 @@ import { CompanyCard } from '@/components/cards/CompanyCard';
 import { ProfileCard } from '@/components/cards/ProfileCard';
 import { Linkify } from '@/components/linkify/Linkify';
 import { COMPANIES } from '@/lib/companies';
-import type { FsDir, FsNode } from '@/lib/filesystem';
+import { compareFileEntries, type FsDir, type FsNode } from '@/lib/filesystem';
 import { TEAM } from '@/lib/team';
 import styles from './FileTree.module.css';
 
@@ -58,7 +58,7 @@ function buildLines(
     .sort((a, b) => a[0].localeCompare(b[0]));
   const files = entries
     .filter(([, v]) => v.type === 'file')
-    .sort((a, b) => a[0].localeCompare(b[0]));
+    .sort((a, b) => compareFileEntries(a[0], b[0], childPath));
   const sorted = [...dirs, ...files];
   sorted.forEach(([name, item], i) => {
     const isLast = i === sorted.length - 1;

--- a/lib/companies.ts
+++ b/lib/companies.ts
@@ -343,25 +343,6 @@ export const COMPANIES: readonly Company[] = [
       'that in AI infrastructure, the openness of the toolchain and the strength of the developer community matter as much as the hardware itself.',
   },
   {
-    // Stealth Fund I investment — file teases the domain, identity disclosed
-    // at launch. CompanyCard renders just `inference.txt: Permission denied`;
-    // no Organization JSON-LD is emitted for stealth slugs.
-    slug: 'inference',
-    company: 'Stealth',
-    oneLiner: 'AI inference stack',
-    folder: 'active',
-    avatar: '', // unused for stealth
-    stealth: true,
-  },
-  {
-    slug: 'specs',
-    company: 'Stealth',
-    oneLiner: 'Specifications framework',
-    folder: 'active',
-    avatar: '',
-    stealth: true,
-  },
-  {
     slug: 'macrodata',
     company: 'Macrodata Labs',
     oneLiner: 'Every strong model starts with great data',
@@ -405,6 +386,25 @@ export const COMPANIES: readonly Company[] = [
       'UMA builds humanoid robots that combine human-level dexterity with a deep understanding of the physical world. The team blends AI research from DeepMind, Tesla Autopilot, and HuggingFace with decades of humanoid-robotics hardware experience to ship general-purpose machines that can take on everyday physical tasks.',
     seoDescription:
       'Humanoid robots with human-level dexterity. Team from DeepMind, Tesla Autopilot, and HuggingFace. >commit Fund I.',
+  },
+  {
+    // Stealth Fund I investment — file teases the domain, identity disclosed
+    // at launch. CompanyCard renders just `inference.txt: Permission denied`;
+    // no Organization JSON-LD is emitted for stealth slugs.
+    slug: 'inference',
+    company: 'Stealth',
+    oneLiner: 'AI inference stack',
+    folder: 'active',
+    avatar: '', // unused for stealth
+    stealth: true,
+  },
+  {
+    slug: 'specs',
+    company: 'Stealth',
+    oneLiner: 'Specifications framework',
+    folder: 'active',
+    avatar: '',
+    stealth: true,
   },
 ] as const;
 

--- a/lib/filesystem.ts
+++ b/lib/filesystem.ts
@@ -172,14 +172,42 @@ export function isDirectory(root: FsDir, path: string): boolean {
   return node !== null && node.type === 'directory';
 }
 
-/** Directories first (alphabetical), then files (alphabetical) — matches the
- *  ordering used by the file-tree sidebar so `ls` and the tree show the same
- *  shape for the same directory. Visibility filtering (e.g. the tree hiding
- *  `private/`) is handled in the renderers, not here. */
+/** Stealth rank for a file's full path: 1 for a stealth company file
+ *  (/companies/<slug>.txt whose slug is flagged stealth), else 0. Lets the
+ *  portfolio listing order public companies before stealth ones. Any
+ *  non-company file ranks 0, so other directories stay plain-alphabetical. */
+function companyStealthRank(fullPath: string): number {
+  const m = fullPath.match(/^\/companies\/([^/]+)\.txt$/);
+  if (!m) return 0;
+  return COMPANIES.find((c) => c.slug === m[1])?.stealth ? 1 : 0;
+}
+
+/** Sort comparator for file entries within a directory: public companies
+ *  before stealth, then alphabetical within each group. `pathOf` maps an
+ *  entry name to its full filesystem path so the stealth check can scope to
+ *  /companies/. Shared by `listDirectory` (CLI `ls`) and the file-tree
+ *  sidebar so both render the same order. */
+export function compareFileEntries(
+  aName: string,
+  bName: string,
+  pathOf: (name: string) => string,
+): number {
+  const ra = companyStealthRank(pathOf(aName));
+  const rb = companyStealthRank(pathOf(bName));
+  if (ra !== rb) return ra - rb;
+  return aName.localeCompare(bName);
+}
+
+/** Directories first (alphabetical), then files (public companies before
+ *  stealth, alphabetical within each group) — matches the ordering used by
+ *  the file-tree sidebar so `ls` and the tree show the same shape for the
+ *  same directory. Visibility filtering (e.g. the tree hiding `private/`) is
+ *  handled in the renderers, not here. */
 export function listDirectory(root: FsDir, path: string): string[] {
   const node = getNode(root, path);
   if (!node || node.type !== 'directory') return [];
   const entries = Object.entries(node.contents);
+  const childPath = (name: string) => (path === '/' ? `/${name}` : `${path}/${name}`);
   const dirs = entries
     .filter(([, v]) => v.type === 'directory')
     .map(([name]) => name)
@@ -187,7 +215,7 @@ export function listDirectory(root: FsDir, path: string): string[] {
   const files = entries
     .filter(([, v]) => v.type === 'file')
     .map(([name]) => name)
-    .sort((a, b) => a.localeCompare(b));
+    .sort((a, b) => compareFileEntries(a, b, childPath));
   return [...dirs, ...files];
 }
 


### PR DESCRIPTION
## What

Reorganize the **active portfolio** so it reads **public companies first, then stealth**, alphabetical within each group:

```
companies/
├── pre-commit/        (unchanged — historical, plain alphabetical)
├── macrodata.txt      ← public
├── uma.txt            ← public
├── inference.txt      ← stealth (dimmed)
└── specs.txt          ← stealth (dimmed)
```

## Why it wasn't just a data reorder

Reordering the `COMPANIES` array alone didn't change what users see: both the file-tree sidebar (`buildLines`) and the CLI `ls` (`listDirectory`) re-sort entries **alphabetically at render time**, which interleaved stealth slugs (`inference`, `specs`) with public ones (`macrodata`, `uma`).

## Change

- Add a shared `compareFileEntries` comparator in `lib/filesystem.ts` that ranks public company files before stealth (then alphabetical within each group).
- Wire it into **both** renderers — the file-tree sidebar and the CLI `ls` — so the tree and terminal stay consistent.
- Non-company files rank 0, so `team/`, `about/`, `blog/`, and `pre-commit/` keep plain alphabetical order.
- The `COMPANIES` array is also reordered to match (public before stealth), keeping array-order renders (e.g. the semantic crawler listing) aligned.

## Verification

- ✅ `tsc --noEmit` passes
- ✅ `filesystem.ts` and its deps are client-safe (no `node:fs`), so importing the comparator into the client `FileTree` doesn't poison the bundle
- ✅ Ran locally — SSR'd `/companies` tree renders `macrodata → uma → inference → specs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)